### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The function is looking against the JSON for either a name match to the same or 
 
 # The CanThey Function
 
-##Initialize and use example
+## Initialize and use example
 ```js
 var canThey = require('canthey').canThey;
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
